### PR TITLE
remove newline when printing token

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func generate(config auth.IssuerConfig, consumer *auth.Consumer) {
 	if err != nil {
 		log.Fatalf("cannot issue token: %v", err)
 	}
-	fmt.Println(token)
+	fmt.Print(token)
 }
 
 func mkdir(path string) {


### PR DESCRIPTION
This is to be friendlier to scripts
For example, passing `jwtl` output to `pbcopy` would otherwise result
in us passing a token with an invalid newline character at the end.